### PR TITLE
fix for column name with punctuation character

### DIFF
--- a/R/fnsComparison.R
+++ b/R/fnsComparison.R
@@ -157,9 +157,10 @@ exclude_columns <- function(both_tables, exclude){
 group_columns <- function(both_tables, group_col){
   message_compareDF("Grouping columns")
   df_combined = rbind(both_tables$df_new %>% mutate(from = "new"), both_tables$df_old %>% mutate(from = "old"))
-  df_combined =  df_combined %>%
+  df_combined = df_combined %>%
     group_by_at(group_col) %>%
-    data.frame(grp = group_indices(.), .) %>% ungroup()
+    data.frame(grp = group_indices(.), ., check.names = FALSE) %>% 
+	ungroup()
   list(df_new = df_combined %>% filter(from == "new") %>% select(-from),
        df_old = df_combined %>% filter(from == "old") %>% select(-from))
 }
@@ -182,8 +183,8 @@ combined_rowdiffs_v2 <- function(both_tables, group_col){
   df_combined[is.na(chng_type), chng_type := TRUE]
 
   list(
-    df1_2 = df_combined[newold_type == 'old' & chng_type,,] %>% data.frame() %>% select(-newold_type, -chng_type),
-    df2_1 = df_combined[newold_type == 'new' & chng_type,,] %>% data.frame() %>% select(-newold_type, -chng_type)
+    df1_2 = df_combined[newold_type == 'old' & chng_type,,] %>% data.frame(check.names = FALSE) %>% select(-newold_type, -chng_type),
+    df2_1 = df_combined[newold_type == 'new' & chng_type,,] %>% data.frame(check.names = FALSE) %>% select(-newold_type, -chng_type)
   )
 }
 
@@ -202,9 +203,9 @@ check_if_similar_after_unique_and_reorder <- function(both_tables, both_diffs, s
 
 create_comparison_table <- function(both_diffs, group_col, round_output_to){
   message_compareDF("Creating comparison table...")
-  mixed_df = both_diffs$df1_2 %>% mutate(chng_type = NA_integer_) %>% slice(0) %>% data.frame()
-  if(nrow(both_diffs$df1_2) != 0) mixed_df = mixed_df %>% rbind(data.frame(chng_type = "1", both_diffs$df1_2))
-  if(nrow(both_diffs$df2_1) != 0) mixed_df = mixed_df %>% rbind(data.frame(chng_type = "2", both_diffs$df2_1))
+  mixed_df = both_diffs$df1_2 %>% mutate(chng_type = NA_integer_) %>% slice(0) %>% data.frame(check.names = FALSE)
+  if(nrow(both_diffs$df1_2) != 0) mixed_df = mixed_df %>% rbind(data.frame(chng_type = "1", both_diffs$df1_2, check.names = FALSE))
+  if(nrow(both_diffs$df2_1) != 0) mixed_df = mixed_df %>% rbind(data.frame(chng_type = "2", both_diffs$df2_1, check.names = FALSE))
   mixed_df %>%
     arrange(desc(chng_type)) %>%
     arrange_at(group_col) %>%
@@ -215,7 +216,8 @@ create_comparison_table <- function(both_diffs, group_col, round_output_to){
 
 create_comparison_table_diff <- function(comparison_table_ts2char, group_col, tolerance, tolerance_type){
   comparison_table_ts2char %>% group_by_at(group_col) %>%
-    do(.diff_type_df(., tolerance = tolerance, tolerance_type = tolerance_type)) %>% as.data.frame
+    do(.diff_type_df(., tolerance = tolerance, tolerance_type = tolerance_type)) %>% 
+	as.data.frame
 }
 
 eliminate_tolerant_rows <- function(comparison_table, comparison_table_diff){
@@ -269,7 +271,7 @@ round_num_cols <- function(df, round_digits = 2)
     }
     # This step decides what colour it should be.
     score = score + score * as.numeric(df$chng_type == "2")
-  }) %>% data.frame
+  }) %>% data.frame(check.names = FALSE)
 }
 
 # Courtesy - Gabor Grothendieck
@@ -298,7 +300,7 @@ sequence_order_vector <- function(data)
 
 create_change_count <- function(comparison_table_ts2char, group_col){
   change_count = comparison_table_ts2char %>% group_by_at(c(group_col, "chng_type")) %>% tally()
-  change_count_replace = change_count %>% tidyr::spread(key = chng_type, value = n) %>% data.frame
+  change_count_replace = change_count %>% tidyr::spread(key = chng_type, value = n) %>% data.frame(check.names = FALSE)
   change_count_replace[is.na(change_count_replace)] = 0
 
   if(is.null(change_count_replace[['X1']])) change_count_replace = change_count_replace %>% mutate(X1 = 0L)
@@ -311,7 +313,7 @@ create_change_count <- function(comparison_table_ts2char, group_col){
     mutate(additions = replace(additions, is.na(additions) | additions < 0, 0)) %>%
     mutate(removals = replace(removals, is.na(removals) | removals < 0, 0))
 
-  change_count %>% data.frame()
+  change_count %>% data.frame(check.names = FALSE)
 
 }
 


### PR DESCRIPTION
If the columns of the input dataset(s) contain unexpected characters, e.g. punctuation signs, the column names are modified to syntactically valid names in R.
For example:
```
data <- beaver1
colnames(data)[which(colnames(data) == "temp")] <- "body temperature (Celsius)"
data_new <- head(data, 5)
data_old <- head(data, 6)
library(compareDF)
dataComp <- compare_df(data_new, data_old)
dataComp$comparison_df
#  rowname chng_type day time body.temperature..Celsius. activ
# 1       6         - 346  930                      36.69     0
```
The names are modified when the data is converted to data.frame. By default, the `data.frame` function converts column names to a valid syntax in R (`check.names = TRUE` by default).
This pull requests ensure that even columns with out valid syntax are retained.